### PR TITLE
docs: fix syntax error in readme sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var specialTokens = new Dictionary<string, int>{
                                             { IM_START, 100264},
                                             { IM_END, 100265},
                                         };
-tokenizer = await TokenizerBuilder.CreateByModelNameAsync("gpt-4", specialTokens);
+var tokenizer = await TokenizerBuilder.CreateByModelNameAsync("gpt-4", specialTokens);
 
 var text = "<|im_start|>Hello World<|im_end|>";
 var encoded = tokenizer.Encode(text, new HashSet<string>(specialTokens.Keys));


### PR DESCRIPTION
Very tiny change, but currently there's a syntax error in the readme since `tokenizer` isn't declared anywhere.  For folks just looking to get up and running as fast as possible, they'll have to fix before proceeding.  

![image](https://github.com/KyleMit/Tokenizer/assets/4307307/b6f7a148-150d-406b-9ba1-c212ed93b12f)
